### PR TITLE
clang-20: remove space between `""` and string literal suffix

### DIFF
--- a/adobe/name.hpp
+++ b/adobe/name.hpp
@@ -98,7 +98,7 @@ namespace literals {
 
 /**************************************************************************************************/
 
-inline constexpr static_name_t operator"" _name(const char* str, std::size_t n);
+inline constexpr static_name_t operator""_name(const char* str, std::size_t n);
 
 /**************************************************************************************************/
 
@@ -161,7 +161,7 @@ private:
 
     friend struct name_t;
 
-    friend constexpr static_name_t literals::operator"" _name(const char* str, std::size_t n);
+    friend constexpr static_name_t literals::operator""_name(const char* str, std::size_t n);
 
     friend std::ostream& operator<<(std::ostream& s, const static_name_t& name);
 
@@ -202,7 +202,7 @@ namespace literals {
         static_name_t foo("foo"_name); // OK
         name_t        bar("bar"_name); // OK
 */
-inline constexpr static_name_t operator"" _name(const char* str, std::size_t n) {
+inline constexpr static_name_t operator""_name(const char* str, std::size_t n) {
     return static_name_t{str, detail::name_hash(str, n)};
 }
 

--- a/test/name/smoke.cpp
+++ b/test/name/smoke.cpp
@@ -29,7 +29,7 @@ namespace {
 
 /**************************************************************************************************/
 
-inline std::ostream& operator"" _dump(const char* str, std::size_t n) {
+inline std::ostream& operator""_dump(const char* str, std::size_t n) {
     return std::cout << "dump: {\n"
                      << "   str: '" << str << "'\n"
                      << "     n: " << n << '\n'


### PR DESCRIPTION
clang-20 does not like the space between `""` and string literal suffix `_dump`/`_name`.